### PR TITLE
修改user_type_info配置

### DIFF
--- a/src/visual.js
+++ b/src/visual.js
@@ -75,7 +75,9 @@ function draw(data) {
     // 长度小于display_barInfo的bar将不显示barInfo
     var display_barInfo = config.display_barInfo;
     // 显示类型
-    if (divide_by != 'name') {
+	if(config.use_type_info){
+		var use_type_info = config.use_type_info;
+	}else if (divide_by != 'name') {
         var use_type_info = true;
     } else {
         var use_type_info = false;


### PR DESCRIPTION
修复user_type_info在divide_by不为name时自动被隐藏而右侧文字依然显示的情况，改为可在config内配置，若不配置则采用divide_by判断