### PR TITLE
增强颜色相关功能：允许用户自定义配色方案，允许使用外部文件指定label 的color 值

### DIFF
--- a/src/bargraph.html
+++ b/src/bargraph.html
@@ -23,6 +23,7 @@
         <script src="config.js"></script>
         <script src="imgs.js"></script>
         <script src="color_ranges.js"></script>
+        <script src="colors.js"></script>
         <script src="visual.js"></script>
         <link rel="stylesheet" href="stylesheet.css">
     </center>

--- a/src/colors.js
+++ b/src/colors.js
@@ -1,0 +1,3 @@
+var external_colors = {
+    Russian: "#18d948"
+}

--- a/src/config.js
+++ b/src/config.js
@@ -30,7 +30,7 @@
   reverse: false,
 
   // 类型根据什么字段区分？如果是name，则关闭类型显示
-  divide_by: "type",
+  divide_by: "name",
 
   // 颜色根据什么字段区分？
   divide_color_by: "name",
@@ -40,6 +40,9 @@
     Chinese: "#1177CC",
     Japanese: "#667788"
   },
+
+  // 指定一组颜色值，用于自定义所有bar 的配色方案。如果为空则使用默认配置。
+  color_palette: [],
 
   // 颜色渐变：颜色绑定增长率
   changeable_color: false,
@@ -98,7 +101,7 @@
   // 如果看不懂这是在干什么的话，建议不要修改这里。
   // 反格式化函数:
   // 格式化操作可能会导致NaN问题。此函数将格式化后的数值反格式化为JS可以识别的数字。
-  deformat: function(val, postfix) {
+  deformat: function (val, postfix) {
     return Number(val.replace(postfix, "").replace(/\,/g, ""));
   },
   //////////////////////////////////////////////////////////////////////////////

--- a/src/config.js
+++ b/src/config.js
@@ -36,6 +36,7 @@
   divide_color_by: "name",
 
   // 字段的值与其对应的颜色值
+  // 也可在src/colors.js 中设置
   color: {
     Chinese: "#1177CC",
     Japanese: "#667788"

--- a/src/config.js
+++ b/src/config.js
@@ -30,7 +30,7 @@
   reverse: false,
 
   // 类型根据什么字段区分？如果是name，则关闭类型显示
-  divide_by: "name",
+  divide_by: "type",
 
   // 颜色根据什么字段区分？
   divide_color_by: "name",

--- a/src/visual.js
+++ b/src/visual.js
@@ -126,6 +126,7 @@ function draw(data) {
   var animation = config.animation;
   var deformat = config.deformat;
   config.imgs = Object.assign(config.imgs, external_imgs);
+  config.color = Object.assign(config.color, external_colors);
 
   const margin = {
     left: left_margin,

--- a/src/visual.js
+++ b/src/visual.js
@@ -57,6 +57,10 @@ function draw(data) {
   // 选择颜色
   function getColor(d) {
     var r = 0.0;
+    // 如果用户提供的color_palette 长度不为0 则使用它，否则使用d3.schemeCatetory10
+    var user_pallete = config.color_palette;
+    var product_palette = user_pallete.length !== 0 ? user_pallete : d3.schemeCategory10;
+
     if (changeable_color) {
       var colorRange = d3.interpolateCubehelix(
         config.color_range[0],
@@ -80,8 +84,8 @@ function draw(data) {
     if (d[divide_color_by] in config.color)
       return config.color[d[divide_color_by]];
     else {
-      return d3.schemeCategory10[
-        Math.floor(d[divide_color_by].charCodeAt() % 10)
+      return product_palette[
+        Math.floor(d[divide_color_by].charCodeAt() % product_palette.length)
       ];
     }
   }

--- a/src/visual.js
+++ b/src/visual.js
@@ -54,13 +54,12 @@ function draw(data) {
     });
   var baseTime = 3000;
 
+  // 如果用户提供的color_palette 长度不为0 则使用它，否则使用d3.schemeCatetory10
+  var user_pallete = config.color_palette;
+  var product_palette = user_pallete.length !== 0 ? user_pallete : d3.schemeCategory10;
   // 选择颜色
   function getColor(d) {
     var r = 0.0;
-    // 如果用户提供的color_palette 长度不为0 则使用它，否则使用d3.schemeCatetory10
-    var user_pallete = config.color_palette;
-    var product_palette = user_pallete.length !== 0 ? user_pallete : d3.schemeCategory10;
-
     if (changeable_color) {
       var colorRange = d3.interpolateCubehelix(
         config.color_range[0],

--- a/src/visual.js
+++ b/src/visual.js
@@ -9,11 +9,11 @@
 // import * as d3 from 'd3';
 // require("./stylesheet.css");
 
-$("#inputfile").change(function() {
+$("#inputfile").change(function () {
   $("#inputfile").attr("hidden", true);
   var r = new FileReader();
   r.readAsText(this.files[0], config.encoding);
-  r.onload = function() {
+  r.onload = function () {
     //读取完成后，数据保存在对象的result属性中
     var data = d3.csvParse(this.result);
     try {
@@ -215,7 +215,7 @@ function draw(data) {
     .attr("style:visibility", dateLabel_switch)
     .attr("x", dateLabel_x)
     .attr("y", dateLabel_y)
-    .attr("text-anchor", function() {
+    .attr("text-anchor", function () {
       return "end";
     })
     .text(currentdate);
@@ -228,7 +228,7 @@ function draw(data) {
 
   function dataSort() {
     if (reverse) {
-      currentData.sort(function(a, b) {
+      currentData.sort(function (a, b) {
         if (Number(a.value) == Number(b.value)) {
           var r1 = 0;
           var r2 = 0;
@@ -244,7 +244,7 @@ function draw(data) {
         }
       });
     } else {
-      currentData.sort(function(a, b) {
+      currentData.sort(function (a, b) {
         if (Number(a.value) == Number(b.value)) {
           var r1 = 0;
           var r2 = 0;
@@ -375,7 +375,7 @@ function draw(data) {
         .transition()
         .duration(baseTime * interval_time)
         .ease(d3.easeLinear)
-        .tween("text", function(d) {
+        .tween("text", function (d) {
           var self = this;
           var i = d3.interpolateDate(
             new Date(self.textContent),
@@ -383,7 +383,7 @@ function draw(data) {
           );
           // var prec = (new Date(d.date) + "").split(".");
           // var round = (prec.length > 1) ? Math.pow(10, prec[1].length) : 1;
-          return function(t) {
+          return function (t) {
             var dateformat = d3.timeFormat(timeFormat);
             self.textContent = dateformat(i(t));
           };
@@ -412,13 +412,13 @@ function draw(data) {
       .domain(currentData.map(d => d.name).reverse())
       .range([innerHeight, 0]);
 
-    var bar = g.selectAll(".bar").data(currentData, function(d) {
+    var bar = g.selectAll(".bar").data(currentData, function (d) {
       return d.name;
     });
 
     if (showMessage) {
       // 榜首文字
-      topLabel.data(currentData).text(function(d) {
+      topLabel.data(currentData).text(function (d) {
         if (lastname == d.name) {
           counter.value = counter.value + step;
         } else {
@@ -435,13 +435,13 @@ function draw(data) {
           .transition()
           .duration(baseTime * interval_time)
           .ease(d3.easeLinear)
-          .tween("text", function(d) {
+          .tween("text", function (d) {
             var self = this;
             var i = d3.interpolate(self.textContent, counter.value),
               prec = (counter.value + "").split("."),
               round = prec.length > 1 ? Math.pow(10, prec[1].length) : 1;
 
-            return function(t) {
+            return function (t) {
               self.textContent = d3.format(format)(
                 Math.round(i(t) * round) / round
               );
@@ -449,7 +449,7 @@ function draw(data) {
           });
       } else if (use_type_info == true) {
         // 榜首type更新
-        top_type.data(currentData).text(function(d) {
+        top_type.data(currentData).text(function (d) {
           return d["type"];
         });
       }
@@ -459,13 +459,13 @@ function draw(data) {
       .enter()
       .insert("g", ".axis")
       .attr("class", "bar")
-      .attr("transform", function(d) {
+      .attr("transform", function (d) {
         return "translate(0," + yScale(yValue(d)) + ")";
       });
 
     barEnter
       .append("rect")
-      .attr("width", function(d) {
+      .attr("width", function (d) {
         if (enter_from_0) {
           return 0;
         } else {
@@ -497,13 +497,13 @@ function draw(data) {
         .duration(2490 * interval_time)
         .attr("fill-opacity", 1)
         .attr("y", 0)
-        .attr("class", function(d) {
+        .attr("class", function (d) {
           return "label ";
         })
         .attr("x", config.labelx)
         .attr("y", 20)
         .attr("text-anchor", "end")
-        .text(function(d) {
+        .text(function (d) {
           if (long) {
             return "";
           }
@@ -554,7 +554,7 @@ function draw(data) {
     // bar上文字
     var barInfo = barEnter
       .append("text")
-      .attr("x", function(d) {
+      .attr("x", function (d) {
         if (long) return 10;
         if (enter_from_0) {
           return 0;
@@ -563,7 +563,7 @@ function draw(data) {
         }
       })
       .attr("stroke", d => getColor(d))
-      .attr("class", function() {
+      .attr("class", function () {
         return "barInfo";
       })
       .attr("y", 50)
@@ -572,7 +572,7 @@ function draw(data) {
       .transition()
       .delay(500 * interval_time)
       .duration(2490 * interval_time)
-      .text(function(d) {
+      .text(function (d) {
         if (use_type_info) {
           return d[divide_by] + "-" + d.name;
         }
@@ -582,7 +582,7 @@ function draw(data) {
         if (long) return 10;
         return xScale(xValue(d)) - 40;
       })
-      .attr("fill-opacity", function(d) {
+      .attr("fill-opacity", function (d) {
         if (xScale(xValue(d)) - 40 < display_barInfo) {
           return 0;
         }
@@ -590,11 +590,11 @@ function draw(data) {
       })
       .attr("y", 2)
       .attr("dy", ".5em")
-      .attr("text-anchor", function() {
+      .attr("text-anchor", function () {
         if (long) return "start";
         return "end";
       })
-      .attr("stroke-width", function(d) {
+      .attr("stroke-width", function (d) {
         if (xScale(xValue(d)) - 40 < display_barInfo) {
           return "0px";
         }
@@ -602,13 +602,13 @@ function draw(data) {
       })
       .attr("paint-order", "stroke");
     if (long) {
-      barInfo.tween("text", function(d) {
+      barInfo.tween("text", function (d) {
         var self = this;
         self.textContent = d.value;
         var i = d3.interpolate(self.textContent, Number(d.value)),
           prec = (Number(d.value) + "").split("."),
           round = prec.length > 1 ? Math.pow(10, prec[1].length) : 1;
-        return function(t) {
+        return function (t) {
           self.textContent =
             d[divide_by] +
             "-" +
@@ -621,7 +621,7 @@ function draw(data) {
     if (!long) {
       barEnter
         .append("text")
-        .attr("x", function() {
+        .attr("x", function () {
           if (long) {
             return 10;
           }
@@ -636,7 +636,7 @@ function draw(data) {
         .style("fill", d => getColor(d))
         .transition()
         .duration(2990 * interval_time)
-        .tween("text", function(d) {
+        .tween("text", function (d) {
           var self = this;
           // 初始值为d.value的0.9倍
           self.textContent = d.value * 0.9;
@@ -644,7 +644,7 @@ function draw(data) {
             prec = (Number(d.value) + "").split("."),
             round = prec.length > 1 ? Math.pow(10, prec[1].length) : 1;
           // d.value = self.textContent
-          return function(t) {
+          return function (t) {
             self.textContent =
               d3.format(format)(Math.round(i(t) * round) / round) +
               config.postfix;
@@ -653,7 +653,7 @@ function draw(data) {
         })
         .attr("fill-opacity", 1)
         .attr("y", 0)
-        .attr("class", function(d) {
+        .attr("class", function (d) {
           return "value";
         })
         .attr("x", d => {
@@ -673,7 +673,7 @@ function draw(data) {
     if (config.showLabel == true) {
       barUpdate
         .select(".label")
-        .attr("class", function(d) {
+        .attr("class", function (d) {
           return "label ";
         })
         .style("fill", d => getColor(d))
@@ -683,20 +683,20 @@ function draw(data) {
     if (!long) {
       barUpdate
         .select(".value")
-        .attr("class", function(d) {
+        .attr("class", function (d) {
           return "value";
         })
         .style("fill", d => getColor(d))
         .attr("width", d => xScale(xValue(d)));
     }
-    barUpdate.select(".barInfo").attr("stroke", function(d) {
+    barUpdate.select(".barInfo").attr("stroke", function (d) {
       return getColor(d);
     });
 
     if (config.use_img) {
       barUpdate
         .select("circle")
-        .attr("stroke", function(d) {
+        .attr("stroke", function (d) {
           return getColor(d);
         })
         .attr("cx", d => xScale(xValue(d)) - 20);
@@ -704,7 +704,7 @@ function draw(data) {
 
     var barInfo = barUpdate
       .select(".barInfo")
-      .text(function(d) {
+      .text(function (d) {
         if (use_type_info) {
           return d[divide_by] + "-" + d.name;
         }
@@ -714,13 +714,13 @@ function draw(data) {
         if (long) return 10;
         return xScale(xValue(d)) - 40;
       })
-      .attr("fill-opacity", function(d) {
+      .attr("fill-opacity", function (d) {
         if (xScale(xValue(d)) - 40 < display_barInfo) {
           return 0;
         }
         return 1;
       })
-      .attr("stroke-width", function(d) {
+      .attr("stroke-width", function (d) {
         if (xScale(xValue(d)) - 40 < display_barInfo) {
           return "0px";
         }
@@ -729,17 +729,17 @@ function draw(data) {
       .attr("paint-order", "stroke");
 
     if (long) {
-      barInfo.tween("text", function(d) {
+      barInfo.tween("text", function (d) {
         var self = this;
         var str = d[divide_by] + "-" + d.name + "  数值:";
 
         var i = d3.interpolate(
-            self.textContent.slice(str.length, 99),
-            Number(d.value)
-          ),
+          self.textContent.slice(str.length, 99),
+          Number(d.value)
+        ),
           prec = (Number(d.value) + "").split("."),
           round = prec.length > 1 ? Math.pow(10, prec[1].length) : 1;
-        return function(t) {
+        return function (t) {
           self.textContent =
             d[divide_by] +
             "-" +
@@ -752,7 +752,7 @@ function draw(data) {
     if (!long) {
       barUpdate
         .select(".value")
-        .tween("text", function(d) {
+        .tween("text", function (d) {
           var self = this;
 
           // if postfix is blank, do not slice.
@@ -773,7 +773,7 @@ function draw(data) {
           var prec = (Number(d.value) + "").split("."),
             round = prec.length > 1 ? Math.pow(10, prec[1].length) : 1;
           // d.value = self.textContent
-          return function(t) {
+          return function (t) {
             self.textContent =
               d3.format(format)(Math.round(i(t) * round) / round) +
               config.postfix;
@@ -794,7 +794,7 @@ function draw(data) {
       .transition()
       .duration(2500 * interval_time);
     barExit
-      .attr("transform", function(d) {
+      .attr("transform", function (d) {
         if (always_up) {
           return "translate(0," + "-100" + ")";
         }
@@ -824,7 +824,7 @@ function draw(data) {
     barExit
       .select(".barInfo")
       .attr("fill-opacity", 0)
-      .attr("stroke-width", function(d) {
+      .attr("stroke-width", function (d) {
         return "0px";
       })
       .attr("x", () => {
@@ -844,23 +844,23 @@ function draw(data) {
       .range([innerHeight, 0]);
     if (animation == "linear") {
       g.selectAll(".bar")
-        .data(currentData, function(d) {
+        .data(currentData, function (d) {
           return d.name;
         })
         .transition("1")
         .ease(d3.easeLinear)
         .duration(baseTime * update_rate * interval_time)
-        .attr("transform", function(d) {
+        .attr("transform", function (d) {
           return "translate(0," + yScale(yValue(d)) + ")";
         });
     } else {
       g.selectAll(".bar")
-        .data(currentData, function(d) {
+        .data(currentData, function (d) {
           return d.name;
         })
         .transition("1")
         .duration(baseTime * update_rate * interval_time)
-        .attr("transform", function(d) {
+        .attr("transform", function (d) {
           return "translate(0," + yScale(yValue(d)) + ")";
         });
     }


### PR DESCRIPTION
增加两个主要功能：
1. config.js 里增加一个属性：color_palette = []。允许用户指定自己的配色方案。如果该属性长度为0 则使用以前的默认方案d3.schemeCategory10。
2. 增加一个外部文件colors.js，方便从外部指定颜色值。与imgs.js 的使用方法相同。